### PR TITLE
feat: helper to build npm packages for process plugins

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,5 +20,7 @@ jobs:
         uses: denoland/setup-deno@v2
         with:
           deno-version: canary
+      - name: Test
+        run: deno task test
       - name: Publish to JSR on tag
         run: deno run -A jsr:@david/publish-on-tag@0.2.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,6 @@ jobs:
         with:
           deno-version: canary
       - name: Test
-        run: deno task test
+        run: deno test -P
       - name: Publish to JSR on tag
         run: deno run -A jsr:@david/publish-on-tag@0.2.0

--- a/deno.json
+++ b/deno.json
@@ -2,10 +2,14 @@
   "name": "@dprint/automation",
   "imports": {
     "dax": "jsr:@david/dax@0.45.0",
-    "semver": "jsr:@std/semver@1"
+    "semver": "jsr:@std/semver@1",
+    "@std/assert": "jsr:@std/assert@1"
   },
   "exports": {
     ".": "./mod.ts",
     "./tasks/publish-release": "./tasks/publish-release.ts"
+  },
+  "tasks": {
+    "test": "deno test -A"
   }
 }

--- a/deno.json
+++ b/deno.json
@@ -9,7 +9,11 @@
     ".": "./mod.ts",
     "./tasks/publish-release": "./tasks/publish-release.ts"
   },
-  "tasks": {
-    "test": "deno test -A"
+  "test": {
+    "permissions": {
+      "all": true
+    },
+    "sanitizeOps": true,
+    "sanitizeResources": true
   }
 }

--- a/deno.lock
+++ b/deno.lock
@@ -1,0 +1,25 @@
+{
+  "version": "5",
+  "specifiers": {
+    "jsr:@std/assert@1": "1.0.19",
+    "jsr:@std/internal@^1.0.12": "1.0.13"
+  },
+  "jsr": {
+    "@std/assert@1.0.19": {
+      "integrity": "eaada96ee120cb980bc47e040f82814d786fe8162ecc53c91d8df60b8755991e",
+      "dependencies": [
+        "jsr:@std/internal"
+      ]
+    },
+    "@std/internal@1.0.13": {
+      "integrity": "2f9546691d4ac2d32859c82dff284aaeac980ddeca38430d07941e7e288725c0"
+    }
+  },
+  "workspace": {
+    "dependencies": [
+      "jsr:@david/dax@0.45.0",
+      "jsr:@std/assert@1",
+      "jsr:@std/semver@1"
+    ]
+  }
+}

--- a/process-plugin.ts
+++ b/process-plugin.ts
@@ -10,6 +10,7 @@ export type Platform =
   | "linux-riscv64"
   | "linux-riscv64-musl"
   | "linux-loongarch64"
+  | "linux-loongarch64-musl"
   | "windows-x86_64"
   | "windows-aarch64";
 
@@ -33,6 +34,8 @@ export function getStandardZipFileName(pluginName: string, platform: Platform): 
       return `${pluginName}-riscv64gc-unknown-linux-musl.zip`;
     case "linux-loongarch64":
       return `${pluginName}-loongarch64-unknown-linux-gnu.zip`;
+    case "linux-loongarch64-musl":
+      return `${pluginName}-loongarch64-unknown-linux-musl.zip`;
     case "windows-x86_64":
       return `${pluginName}-x86_64-pc-windows-msvc.zip`;
     case "windows-aarch64":
@@ -128,10 +131,19 @@ export interface CreateDprintOrgNpmPackagesOptions {
   version: string;
   /**
    * The npm package name for the main package (may be scoped,
-   * e.g. `@dprint/exec`). Per-platform sub-packages are named
-   * `<mainPackageName>-<platform>`.
+   * e.g. `@dprint/exec`).
    */
   mainPackageName: string;
+  /**
+   * Prefix prepended to each platform suffix to form a sub-package name.
+   * Defaults to `${mainPackageName}-`, producing names like
+   * `@dprint/exec-linux-x64-glibc`.
+   *
+   * Pass e.g. `"@dprint/"` to produce names like `@dprint/linux-x64-glibc`
+   * (the convention used by the dprint CLI itself, where sub-packages share
+   * the scope but not the basename of the main package).
+   */
+  subPackagePrefix?: string;
   /** Per-platform zips that will be packed as sub-packages. */
   platforms: { platform: Platform; zipFilePath: string }[];
   /** Directory in which to write the package subdirectories. */
@@ -158,15 +170,24 @@ export interface CreateDprintOrgNpmPackagesResult {
 /**
  * Creates the npm package directory structure for a dprint-org process plugin.
  *
- * For each platform it writes `<outDir>/<basename>-<platform>/`
- * containing `package.json` (with `os`/`cpu`/`libc` filters) and `plugin.zip`.
- * It also writes the main package at `<outDir>/<basename>/` whose
- * `plugin.json` references each sub-package via
- * `npm:<sub-package>@<version>/plugin.zip` and whose `package.json` lists
- * every sub-package as an `optionalDependencies` entry pinned to `version`.
+ * For each platform it writes
+ * `<outDir>/<sub-package-basename>/{package.json, plugin.zip}`. Sub-package
+ * `package.json` files carry `os`/`cpu`/`libc` filters using Node's canonical
+ * values (e.g. `linux` / `x64` / `glibc`) so npm only installs the matching
+ * one. The platform suffix matches the convention used by the dprint CLI:
+ * `darwin-x64`, `darwin-arm64`, `linux-x64-glibc`, `linux-x64-musl`,
+ * `linux-arm64-glibc`, `linux-arm64-musl`, `linux-riscv64-glibc`,
+ * `linux-riscv64-musl`, `linux-loong64-glibc`, `linux-loong64-musl`,
+ * `win32-x64`, `win32-arm64`.
  *
- * `basename` is the last `/`-separated segment of `mainPackageName`
- * (e.g. `@dprint/exec` → `exec`).
+ * It also writes the main package at
+ * `<outDir>/<main-package-basename>/{package.json, plugin.json}`. The
+ * `plugin.json` references each sub-package via
+ * `npm:<sub-package>@<version>/plugin.zip` and the `package.json` lists every
+ * sub-package as an `optionalDependencies` entry pinned to `version`.
+ *
+ * `basename` here is the last `/`-separated segment of the package name (e.g.
+ * `@dprint/exec` → `exec`).
  *
  * The caller is expected to `npm publish` each sub-package directory first,
  * then the main package directory.
@@ -181,20 +202,23 @@ export async function createDprintOrgNpmPackages(
 
   await Deno.mkdir(options.outDir, { recursive: true });
 
-  const basename = packageBasename(options.mainPackageName);
+  const subPackagePrefix = options.subPackagePrefix ?? `${options.mainPackageName}-`;
   const subPackageDirs: string[] = [];
   const optionalDependencies: Record<string, string> = {};
 
   for (const { platform, zipFilePath } of options.platforms) {
-    const subPackageName = `${options.mainPackageName}-${platform}`;
-    const subPackageDir = `${options.outDir}/${basename}-${platform}`;
+    const info = npmPlatformInfo(platform);
+    const subPackageName = `${subPackagePrefix}${info.suffix}`;
+    const subPackageDir = `${options.outDir}/${packageBasename(subPackageName)}`;
     await Deno.mkdir(subPackageDir, { recursive: true });
     await Deno.copyFile(zipFilePath, `${subPackageDir}/plugin.zip`);
     await writeJsonFile(`${subPackageDir}/package.json`, {
       ...options.packageJsonExtra,
       name: subPackageName,
       version: options.version,
-      ...npmPlatformFilters(platform),
+      os: info.os,
+      cpu: info.cpu,
+      ...(info.libc ? { libc: info.libc } : {}),
     });
     subPackageDirs.push(subPackageDir);
     optionalDependencies[subPackageName] = options.version;
@@ -206,7 +230,7 @@ export async function createDprintOrgNpmPackages(
     });
   }
 
-  const mainPackageDir = `${options.outDir}/${basename}`;
+  const mainPackageDir = `${options.outDir}/${packageBasename(options.mainPackageName)}`;
   await Deno.mkdir(mainPackageDir, { recursive: true });
   await builder.writeToPath(`${mainPackageDir}/plugin.json`);
   await writeJsonFile(`${mainPackageDir}/package.json`, {
@@ -266,32 +290,43 @@ function packageBasename(npmName: string): string {
   return slashIdx >= 0 ? npmName.substring(slashIdx + 1) : npmName;
 }
 
-function npmPlatformFilters(
-  platform: Platform,
-): { os: string[]; cpu: string[]; libc?: string[] } {
+interface NpmPlatformInfo {
+  /** Package-name suffix matching the dprint CLI convention. */
+  suffix: string;
+  /** Value of the npm `os` field. */
+  os: string[];
+  /** Value of the npm `cpu` field. */
+  cpu: string[];
+  /** Value of the npm `libc` field (omitted on darwin/win32). */
+  libc?: string[];
+}
+
+function npmPlatformInfo(platform: Platform): NpmPlatformInfo {
   switch (platform) {
     case "darwin-x86_64":
-      return { os: ["darwin"], cpu: ["x64"] };
+      return { suffix: "darwin-x64", os: ["darwin"], cpu: ["x64"] };
     case "darwin-aarch64":
-      return { os: ["darwin"], cpu: ["arm64"] };
+      return { suffix: "darwin-arm64", os: ["darwin"], cpu: ["arm64"] };
     case "linux-x86_64":
-      return { os: ["linux"], cpu: ["x64"], libc: ["glibc"] };
+      return { suffix: "linux-x64-glibc", os: ["linux"], cpu: ["x64"], libc: ["glibc"] };
     case "linux-x86_64-musl":
-      return { os: ["linux"], cpu: ["x64"], libc: ["musl"] };
+      return { suffix: "linux-x64-musl", os: ["linux"], cpu: ["x64"], libc: ["musl"] };
     case "linux-aarch64":
-      return { os: ["linux"], cpu: ["arm64"], libc: ["glibc"] };
+      return { suffix: "linux-arm64-glibc", os: ["linux"], cpu: ["arm64"], libc: ["glibc"] };
     case "linux-aarch64-musl":
-      return { os: ["linux"], cpu: ["arm64"], libc: ["musl"] };
+      return { suffix: "linux-arm64-musl", os: ["linux"], cpu: ["arm64"], libc: ["musl"] };
     case "linux-riscv64":
-      return { os: ["linux"], cpu: ["riscv64"], libc: ["glibc"] };
+      return { suffix: "linux-riscv64-glibc", os: ["linux"], cpu: ["riscv64"], libc: ["glibc"] };
     case "linux-riscv64-musl":
-      return { os: ["linux"], cpu: ["riscv64"], libc: ["musl"] };
+      return { suffix: "linux-riscv64-musl", os: ["linux"], cpu: ["riscv64"], libc: ["musl"] };
     case "linux-loongarch64":
-      return { os: ["linux"], cpu: ["loong64"] };
+      return { suffix: "linux-loong64-glibc", os: ["linux"], cpu: ["loong64"], libc: ["glibc"] };
+    case "linux-loongarch64-musl":
+      return { suffix: "linux-loong64-musl", os: ["linux"], cpu: ["loong64"], libc: ["musl"] };
     case "windows-x86_64":
-      return { os: ["win32"], cpu: ["x64"] };
+      return { suffix: "win32-x64", os: ["win32"], cpu: ["x64"] };
     case "windows-aarch64":
-      return { os: ["win32"], cpu: ["arm64"] };
+      return { suffix: "win32-arm64", os: ["win32"], cpu: ["arm64"] };
     default: {
       const _never: never = platform;
       throw new Error(`Not supported platform: ${platform}`);

--- a/process-plugin.ts
+++ b/process-plugin.ts
@@ -9,6 +9,7 @@ export type Platform =
   | "linux-aarch64-musl"
   | "linux-riscv64"
   | "linux-riscv64-musl"
+  | "linux-loongarch64"
   | "windows-x86_64"
   | "windows-aarch64";
 
@@ -30,6 +31,8 @@ export function getStandardZipFileName(pluginName: string, platform: Platform): 
       return `${pluginName}-riscv64gc-unknown-linux-gnu.zip`;
     case "linux-riscv64-musl":
       return `${pluginName}-riscv64gc-unknown-linux-musl.zip`;
+    case "linux-loongarch64":
+      return `${pluginName}-loongarch64-unknown-linux-gnu.zip`;
     case "windows-x86_64":
       return `${pluginName}-x86_64-pc-windows-msvc.zip`;
     case "windows-aarch64":
@@ -117,6 +120,105 @@ export class PluginFileBuilder {
   }
 }
 
+/** Options for {@link createDprintOrgNpmPackages}. */
+export interface CreateDprintOrgNpmPackagesOptions {
+  /** Name of the plugin as it appears in `plugin.json` (matches Cargo.toml). */
+  pluginName: string;
+  /** Version of the plugin. */
+  version: string;
+  /**
+   * The npm package name for the main package (may be scoped,
+   * e.g. `@dprint/exec`). Per-platform sub-packages are named
+   * `<mainPackageName>-<platform>`.
+   */
+  mainPackageName: string;
+  /** Per-platform zips that will be packed as sub-packages. */
+  platforms: { platform: Platform; zipFilePath: string }[];
+  /** Directory in which to write the package subdirectories. */
+  outDir: string;
+  /**
+   * Extra fields merged into every generated `package.json`. The fields
+   * `name`, `version`, `os`, `cpu`, `libc`, and `optionalDependencies` are
+   * always set by this function and override any value provided here.
+   */
+  packageJsonExtra?: Record<string, unknown>;
+}
+
+/** Result of {@link createDprintOrgNpmPackages}. */
+export interface CreateDprintOrgNpmPackagesResult {
+  /** Directory containing the main package (run `npm publish` here last). */
+  mainPackageDir: string;
+  /**
+   * Directories containing the per-platform sub-packages. Publish these
+   * before the main package so its `optionalDependencies` resolve.
+   */
+  subPackageDirs: string[];
+}
+
+/**
+ * Creates the npm package directory structure for a dprint-org process plugin.
+ *
+ * For each platform it writes `<outDir>/<basename>-<platform>/`
+ * containing `package.json` (with `os`/`cpu`/`libc` filters) and `plugin.zip`.
+ * It also writes the main package at `<outDir>/<basename>/` whose
+ * `plugin.json` references each sub-package via
+ * `npm:<sub-package>@<version>/plugin.zip` and whose `package.json` lists
+ * every sub-package as an `optionalDependencies` entry pinned to `version`.
+ *
+ * `basename` is the last `/`-separated segment of `mainPackageName`
+ * (e.g. `@dprint/exec` → `exec`).
+ *
+ * The caller is expected to `npm publish` each sub-package directory first,
+ * then the main package directory.
+ */
+export async function createDprintOrgNpmPackages(
+  options: CreateDprintOrgNpmPackagesOptions,
+): Promise<CreateDprintOrgNpmPackagesResult> {
+  const builder = new PluginFileBuilder({
+    name: options.pluginName,
+    version: options.version,
+  });
+
+  await Deno.mkdir(options.outDir, { recursive: true });
+
+  const basename = packageBasename(options.mainPackageName);
+  const subPackageDirs: string[] = [];
+  const optionalDependencies: Record<string, string> = {};
+
+  for (const { platform, zipFilePath } of options.platforms) {
+    const subPackageName = `${options.mainPackageName}-${platform}`;
+    const subPackageDir = `${options.outDir}/${basename}-${platform}`;
+    await Deno.mkdir(subPackageDir, { recursive: true });
+    await Deno.copyFile(zipFilePath, `${subPackageDir}/plugin.zip`);
+    await writeJsonFile(`${subPackageDir}/package.json`, {
+      ...options.packageJsonExtra,
+      name: subPackageName,
+      version: options.version,
+      ...npmPlatformFilters(platform),
+    });
+    subPackageDirs.push(subPackageDir);
+    optionalDependencies[subPackageName] = options.version;
+
+    await builder.addPlatform({
+      platform,
+      zipFilePath,
+      zipUrl: `npm:${subPackageName}@${options.version}/plugin.zip`,
+    });
+  }
+
+  const mainPackageDir = `${options.outDir}/${basename}`;
+  await Deno.mkdir(mainPackageDir, { recursive: true });
+  await builder.writeToPath(`${mainPackageDir}/plugin.json`);
+  await writeJsonFile(`${mainPackageDir}/package.json`, {
+    ...options.packageJsonExtra,
+    name: options.mainPackageName,
+    version: options.version,
+    optionalDependencies,
+  });
+
+  return { mainPackageDir, subPackageDirs };
+}
+
 /** Creates a process plugin for the dprint GitHub organization. */
 export async function createDprintOrgProcessPlugin({ pluginName, version, platforms, isTest }: {
   pluginName: string;
@@ -157,4 +259,46 @@ export async function createDprintOrgProcessPlugin({ pluginName, version, platfo
       zipUrl,
     });
   }
+}
+
+function packageBasename(npmName: string): string {
+  const slashIdx = npmName.lastIndexOf("/");
+  return slashIdx >= 0 ? npmName.substring(slashIdx + 1) : npmName;
+}
+
+function npmPlatformFilters(
+  platform: Platform,
+): { os: string[]; cpu: string[]; libc?: string[] } {
+  switch (platform) {
+    case "darwin-x86_64":
+      return { os: ["darwin"], cpu: ["x64"] };
+    case "darwin-aarch64":
+      return { os: ["darwin"], cpu: ["arm64"] };
+    case "linux-x86_64":
+      return { os: ["linux"], cpu: ["x64"], libc: ["glibc"] };
+    case "linux-x86_64-musl":
+      return { os: ["linux"], cpu: ["x64"], libc: ["musl"] };
+    case "linux-aarch64":
+      return { os: ["linux"], cpu: ["arm64"], libc: ["glibc"] };
+    case "linux-aarch64-musl":
+      return { os: ["linux"], cpu: ["arm64"], libc: ["musl"] };
+    case "linux-riscv64":
+      return { os: ["linux"], cpu: ["riscv64"], libc: ["glibc"] };
+    case "linux-riscv64-musl":
+      return { os: ["linux"], cpu: ["riscv64"], libc: ["musl"] };
+    case "linux-loongarch64":
+      return { os: ["linux"], cpu: ["loong64"] };
+    case "windows-x86_64":
+      return { os: ["win32"], cpu: ["x64"] };
+    case "windows-aarch64":
+      return { os: ["win32"], cpu: ["arm64"] };
+    default: {
+      const _never: never = platform;
+      throw new Error(`Not supported platform: ${platform}`);
+    }
+  }
+}
+
+async function writeJsonFile(filePath: string, value: unknown): Promise<void> {
+  await Deno.writeTextFile(filePath, JSON.stringify(value, undefined, 2) + "\n");
 }

--- a/process-plugin.ts
+++ b/process-plugin.ts
@@ -218,7 +218,9 @@ export async function createDprintOrgNpmPackages(
       version: options.version,
       os: info.os,
       cpu: info.cpu,
-      ...(info.libc ? { libc: info.libc } : {}),
+      // undefined keys are dropped by JSON.stringify, so this also overrides
+      // any `libc` field provided via packageJsonExtra for darwin/win32.
+      libc: info.libc,
     });
     subPackageDirs.push(subPackageDir);
     optionalDependencies[subPackageName] = options.version;

--- a/process-plugin_test.ts
+++ b/process-plugin_test.ts
@@ -1,0 +1,340 @@
+import { assertEquals } from "@std/assert";
+import { getChecksum } from "./hash.ts";
+import {
+  createDprintOrgNpmPackages,
+  getStandardZipFileName,
+  type Platform,
+  PluginFileBuilder,
+} from "./process-plugin.ts";
+
+Deno.test("getStandardZipFileName maps every Platform variant", () => {
+  const cases: Array<[Platform, string]> = [
+    ["darwin-x86_64", "foo-x86_64-apple-darwin.zip"],
+    ["darwin-aarch64", "foo-aarch64-apple-darwin.zip"],
+    ["linux-x86_64", "foo-x86_64-unknown-linux-gnu.zip"],
+    ["linux-x86_64-musl", "foo-x86_64-unknown-linux-musl.zip"],
+    ["linux-aarch64", "foo-aarch64-unknown-linux-gnu.zip"],
+    ["linux-aarch64-musl", "foo-aarch64-unknown-linux-musl.zip"],
+    ["linux-riscv64", "foo-riscv64gc-unknown-linux-gnu.zip"],
+    ["linux-riscv64-musl", "foo-riscv64gc-unknown-linux-musl.zip"],
+    ["linux-loongarch64", "foo-loongarch64-unknown-linux-gnu.zip"],
+    ["linux-loongarch64-musl", "foo-loongarch64-unknown-linux-musl.zip"],
+    ["windows-x86_64", "foo-x86_64-pc-windows-msvc.zip"],
+    ["windows-aarch64", "foo-aarch64-pc-windows-msvc.zip"],
+  ];
+  for (const [platform, expected] of cases) {
+    assertEquals(getStandardZipFileName("foo", platform), expected);
+  }
+});
+
+Deno.test("PluginFileBuilder outputs canonical schema and matching checksum", async () => {
+  await withTempDir(async (root) => {
+    const zipPath = `${root}/z.zip`;
+    const bytes = new Uint8Array([10, 20, 30, 40]);
+    await Deno.writeFile(zipPath, bytes);
+    const expectedZipChecksum = await getChecksum(bytes);
+
+    const builder = new PluginFileBuilder({ name: "foo", version: "1.0.0" });
+    assertEquals(builder.pluginName, "foo");
+    assertEquals(builder.version, "1.0.0");
+
+    await builder.addPlatform({
+      platform: "linux-x86_64",
+      zipFilePath: zipPath,
+      zipUrl: "https://example.com/foo-linux.zip",
+    });
+
+    assertEquals(JSON.parse(builder.outputText()), {
+      schemaVersion: 2,
+      kind: "process",
+      name: "foo",
+      version: "1.0.0",
+      "linux-x86_64": {
+        reference: "https://example.com/foo-linux.zip",
+        checksum: expectedZipChecksum,
+      },
+    });
+
+    assertEquals(builder.outputText().endsWith("\n"), true);
+
+    assertEquals(
+      await builder.outputTextChecksum(),
+      await getChecksum(new TextEncoder().encode(builder.outputText())),
+    );
+  });
+});
+
+Deno.test("PluginFileBuilder.writeToPath writes outputText verbatim", async () => {
+  await withTempDir(async (root) => {
+    const builder = new PluginFileBuilder({ name: "foo", version: "9.9.9" });
+    const path = `${root}/plugin.json`;
+    await builder.writeToPath(path);
+    assertEquals(await Deno.readTextFile(path), builder.outputText());
+  });
+});
+
+Deno.test("createDprintOrgNpmPackages: full layout for plugin convention", async () => {
+  await withTempDir(async (root) => {
+    const linuxZip = `${root}/linux.zip`;
+    const darwinZip = `${root}/darwin.zip`;
+    const winZip = `${root}/win.zip`;
+    const linuxBytes = new TextEncoder().encode("linux zip content");
+    const darwinBytes = new TextEncoder().encode("darwin zip content");
+    const winBytes = new TextEncoder().encode("win zip content");
+    await Deno.writeFile(linuxZip, linuxBytes);
+    await Deno.writeFile(darwinZip, darwinBytes);
+    await Deno.writeFile(winZip, winBytes);
+
+    const outDir = `${root}/out`;
+    const result = await createDprintOrgNpmPackages({
+      pluginName: "dprint-plugin-exec",
+      version: "1.2.3",
+      mainPackageName: "@dprint/exec",
+      outDir,
+      platforms: [
+        { platform: "linux-x86_64", zipFilePath: linuxZip },
+        { platform: "darwin-aarch64", zipFilePath: darwinZip },
+        { platform: "windows-x86_64", zipFilePath: winZip },
+      ],
+    });
+
+    assertEquals(result.mainPackageDir, `${outDir}/exec`);
+    assertEquals(result.subPackageDirs, [
+      `${outDir}/exec-linux-x64-glibc`,
+      `${outDir}/exec-darwin-arm64`,
+      `${outDir}/exec-win32-x64`,
+    ]);
+
+    assertEquals(await listRelativeFiles(outDir), [
+      "exec-darwin-arm64/package.json",
+      "exec-darwin-arm64/plugin.zip",
+      "exec-linux-x64-glibc/package.json",
+      "exec-linux-x64-glibc/plugin.zip",
+      "exec-win32-x64/package.json",
+      "exec-win32-x64/plugin.zip",
+      "exec/package.json",
+      "exec/plugin.json",
+    ]);
+
+    assertEquals(
+      JSON.parse(await Deno.readTextFile(`${outDir}/exec/package.json`)),
+      {
+        name: "@dprint/exec",
+        version: "1.2.3",
+        optionalDependencies: {
+          "@dprint/exec-linux-x64-glibc": "1.2.3",
+          "@dprint/exec-darwin-arm64": "1.2.3",
+          "@dprint/exec-win32-x64": "1.2.3",
+        },
+      },
+    );
+
+    assertEquals(
+      JSON.parse(await Deno.readTextFile(`${outDir}/exec/plugin.json`)),
+      {
+        schemaVersion: 2,
+        kind: "process",
+        name: "dprint-plugin-exec",
+        version: "1.2.3",
+        "linux-x86_64": {
+          reference: "npm:@dprint/exec-linux-x64-glibc@1.2.3/plugin.zip",
+          checksum: await getChecksum(linuxBytes),
+        },
+        "darwin-aarch64": {
+          reference: "npm:@dprint/exec-darwin-arm64@1.2.3/plugin.zip",
+          checksum: await getChecksum(darwinBytes),
+        },
+        "windows-x86_64": {
+          reference: "npm:@dprint/exec-win32-x64@1.2.3/plugin.zip",
+          checksum: await getChecksum(winBytes),
+        },
+      },
+    );
+
+    assertEquals(
+      JSON.parse(
+        await Deno.readTextFile(`${outDir}/exec-linux-x64-glibc/package.json`),
+      ),
+      {
+        name: "@dprint/exec-linux-x64-glibc",
+        version: "1.2.3",
+        os: ["linux"],
+        cpu: ["x64"],
+        libc: ["glibc"],
+      },
+    );
+
+    assertEquals(
+      JSON.parse(
+        await Deno.readTextFile(`${outDir}/exec-darwin-arm64/package.json`),
+      ),
+      {
+        name: "@dprint/exec-darwin-arm64",
+        version: "1.2.3",
+        os: ["darwin"],
+        cpu: ["arm64"],
+      },
+    );
+
+    assertEquals(
+      JSON.parse(
+        await Deno.readTextFile(`${outDir}/exec-win32-x64/package.json`),
+      ),
+      {
+        name: "@dprint/exec-win32-x64",
+        version: "1.2.3",
+        os: ["win32"],
+        cpu: ["x64"],
+      },
+    );
+
+    assertEquals(
+      await Deno.readFile(`${outDir}/exec-linux-x64-glibc/plugin.zip`),
+      linuxBytes,
+    );
+  });
+});
+
+Deno.test("createDprintOrgNpmPackages: subPackagePrefix produces CLI-style names", async () => {
+  await withTempDir(async (root) => {
+    const zip = `${root}/z.zip`;
+    await Deno.writeFile(zip, new Uint8Array([1, 2, 3]));
+
+    const outDir = `${root}/out`;
+    const result = await createDprintOrgNpmPackages({
+      pluginName: "dprint",
+      version: "0.54.0",
+      mainPackageName: "dprint",
+      subPackagePrefix: "@dprint/",
+      outDir,
+      platforms: [
+        { platform: "linux-x86_64", zipFilePath: zip },
+        { platform: "windows-x86_64", zipFilePath: zip },
+      ],
+    });
+
+    assertEquals(result.mainPackageDir, `${outDir}/dprint`);
+    assertEquals(result.subPackageDirs, [
+      `${outDir}/linux-x64-glibc`,
+      `${outDir}/win32-x64`,
+    ]);
+
+    const mainPkg = JSON.parse(
+      await Deno.readTextFile(`${outDir}/dprint/package.json`),
+    );
+    assertEquals(mainPkg.name, "dprint");
+    assertEquals(mainPkg.optionalDependencies, {
+      "@dprint/linux-x64-glibc": "0.54.0",
+      "@dprint/win32-x64": "0.54.0",
+    });
+
+    assertEquals(
+      JSON.parse(
+        await Deno.readTextFile(`${outDir}/linux-x64-glibc/package.json`),
+      ).name,
+      "@dprint/linux-x64-glibc",
+    );
+
+    const pluginJson = JSON.parse(
+      await Deno.readTextFile(`${outDir}/dprint/plugin.json`),
+    );
+    assertEquals(
+      pluginJson["linux-x86_64"].reference,
+      "npm:@dprint/linux-x64-glibc@0.54.0/plugin.zip",
+    );
+    assertEquals(
+      pluginJson["windows-x86_64"].reference,
+      "npm:@dprint/win32-x64@0.54.0/plugin.zip",
+    );
+  });
+});
+
+Deno.test("createDprintOrgNpmPackages: packageJsonExtra merges but managed fields win", async () => {
+  await withTempDir(async (root) => {
+    const zip = `${root}/z.zip`;
+    await Deno.writeFile(zip, new Uint8Array([0]));
+
+    const outDir = `${root}/out`;
+    await createDprintOrgNpmPackages({
+      pluginName: "p",
+      version: "1.0.0",
+      mainPackageName: "@x/p",
+      outDir,
+      platforms: [
+        // darwin has no libc — managed override must drop a stray
+        // libc value supplied via packageJsonExtra.
+        { platform: "darwin-aarch64", zipFilePath: zip },
+      ],
+      packageJsonExtra: {
+        description: "desc",
+        license: "MIT",
+        repository: { type: "git", url: "git+https://example.com/x.git" },
+        // attempted overrides — must all be ignored
+        name: "WRONG",
+        version: "9.9.9",
+        os: ["should-be-overridden"],
+        cpu: ["should-be-overridden"],
+        libc: ["should-be-dropped"],
+        optionalDependencies: { foo: "1" },
+      },
+    });
+
+    const mainPkg = JSON.parse(
+      await Deno.readTextFile(`${outDir}/p/package.json`),
+    );
+    assertEquals(mainPkg.description, "desc");
+    assertEquals(mainPkg.license, "MIT");
+    assertEquals(mainPkg.repository, {
+      type: "git",
+      url: "git+https://example.com/x.git",
+    });
+    assertEquals(mainPkg.name, "@x/p");
+    assertEquals(mainPkg.version, "1.0.0");
+    assertEquals(mainPkg.optionalDependencies, {
+      "@x/p-darwin-arm64": "1.0.0",
+    });
+
+    const subPkg = JSON.parse(
+      await Deno.readTextFile(`${outDir}/p-darwin-arm64/package.json`),
+    );
+    assertEquals(subPkg.description, "desc");
+    assertEquals(subPkg.license, "MIT");
+    assertEquals(subPkg.name, "@x/p-darwin-arm64");
+    assertEquals(subPkg.version, "1.0.0");
+    assertEquals(subPkg.os, ["darwin"]);
+    assertEquals(subPkg.cpu, ["arm64"]);
+    // libc was supplied via packageJsonExtra but must be dropped on darwin
+    assertEquals(Object.hasOwn(subPkg, "libc"), false);
+  });
+});
+
+async function withTempDir(fn: (dir: string) => Promise<void>) {
+  const dir = await Deno.makeTempDir();
+  try {
+    await fn(normalizePath(dir));
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+}
+
+async function listRelativeFiles(root: string): Promise<string[]> {
+  const out: string[] = [];
+  await walk(root, (p) => out.push(p.substring(root.length + 1)));
+  out.sort();
+  return out;
+}
+
+async function walk(dir: string, visit: (path: string) => void): Promise<void> {
+  for await (const entry of Deno.readDir(dir)) {
+    const path = `${dir}/${entry.name}`;
+    if (entry.isDirectory) {
+      await walk(path, visit);
+    } else {
+      visit(path);
+    }
+  }
+}
+
+function normalizePath(path: string): string {
+  return path.replaceAll("\\", "/");
+}


### PR DESCRIPTION
## Summary

Adds `processPlugin.createDprintOrgNpmPackages(...)` — a helper that produces the npm package directory structure dprint's npm resolver expects:

- **Main package** (`<outDir>/<basename>/`) with:
  - `plugin.json` — schema v2, `kind: process`, per-platform entries with `reference: npm:<sub-package>@<version>/plugin.zip` and the matching sha256 `checksum`.
  - `package.json` — lists every sub-package in `optionalDependencies` pinned to `version`.
- **Per-platform sub-packages** (`<outDir>/<basename>-<platform>/`) with:
  - `package.json` — `os`/`cpu`/`libc` filters so npm only installs the matching one.
  - `plugin.zip` — copied from the input zip.

`basename` is the last `/`-separated segment of `mainPackageName`, e.g. `@dprint/exec` → `exec`. The function returns the main package directory and the list of sub-package directories so the caller can `npm publish` sub-packages first then the main package.

Also adds `linux-loongarch64` to the `Platform` union and the `getStandardZipFileName` switch (used by `dprint-plugin-exec`'s existing `create_plugin_file.ts`).

## Test plan

- [x] `deno check process-plugin.ts` / `deno check mod.ts` pass
- [x] `dprint check` passes
- [x] Smoke-tested locally with `@dprint/exec` + linux-x86_64/darwin-aarch64/linux-loongarch64 — produced the expected layout, references, checksums, and `os`/`cpu`/`libc` filters.
- [ ] After merge + release, will be consumed by `dprint-plugin-exec`'s `draft_release` job to publish an npm distribution alongside the existing GitHub release artifacts.