### PR TITLE
feat: ship raw binaries (not zips) in npm process-plugin packages

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -9,6 +9,11 @@
     ".": "./mod.ts",
     "./tasks/publish-release": "./tasks/publish-release.ts"
   },
+  "lint": {
+    "rules": {
+      "exclude": ["no-explicit-any"]
+    }
+  },
   "test": {
     "permissions": {
       "all": true

--- a/deno.lock
+++ b/deno.lock
@@ -1,18 +1,82 @@
 {
   "version": "5",
   "specifiers": {
+    "jsr:@david/console-static-text@0.3": "0.3.4",
+    "jsr:@david/dax@0.45.0": "0.45.0",
+    "jsr:@david/path@0.2": "0.2.0",
+    "jsr:@david/which@~0.4.1": "0.4.2",
     "jsr:@std/assert@1": "1.0.19",
-    "jsr:@std/internal@^1.0.12": "1.0.13"
+    "jsr:@std/bytes@^1.0.6": "1.0.6",
+    "jsr:@std/fmt@1": "1.0.10",
+    "jsr:@std/fs@1": "1.0.23",
+    "jsr:@std/internal@^1.0.12": "1.0.13",
+    "jsr:@std/io@0.225": "0.225.3",
+    "jsr:@std/path@1": "1.1.4",
+    "jsr:@std/path@^1.1.4": "1.1.4",
+    "jsr:@std/semver@1": "1.0.8"
   },
   "jsr": {
+    "@david/console-static-text@0.3.4": {
+      "integrity": "1c596f500b075ff3c8bab1d328ca7148a88067fd9a506b16a73eeaf230c229fd"
+    },
+    "@david/dax@0.45.0": {
+      "integrity": "ac7565dc5c3e5be953a18b505e5dd0d8a30ed53656b65fd34a53bd8d2d5d6b1e",
+      "dependencies": [
+        "jsr:@david/console-static-text",
+        "jsr:@david/path",
+        "jsr:@david/which",
+        "jsr:@std/fmt",
+        "jsr:@std/fs",
+        "jsr:@std/io",
+        "jsr:@std/path@1"
+      ]
+    },
+    "@david/path@0.2.0": {
+      "integrity": "f2d7aa7f02ce5a55e27c09f9f1381794acb09d328f8d3c8a2e3ab3ffc294dccd",
+      "dependencies": [
+        "jsr:@std/fs",
+        "jsr:@std/path@1"
+      ]
+    },
+    "@david/which@0.4.2": {
+      "integrity": "440ee262bc0673b57a39ad4d0dc5673e515ddd41c049a55b2588a0881e5d4a8c"
+    },
     "@std/assert@1.0.19": {
       "integrity": "eaada96ee120cb980bc47e040f82814d786fe8162ecc53c91d8df60b8755991e",
       "dependencies": [
         "jsr:@std/internal"
       ]
     },
+    "@std/bytes@1.0.6": {
+      "integrity": "f6ac6adbd8ccd99314045f5703e23af0a68d7f7e58364b47d2c7f408aeb5820a"
+    },
+    "@std/fmt@1.0.10": {
+      "integrity": "90dfba288802ac6de82fb31d0917eb9e4450b9925b954d5e51fc29ac07419db5"
+    },
+    "@std/fs@1.0.23": {
+      "integrity": "3ecbae4ce4fee03b180fa710caff36bb5adb66631c46a6460aaad49515565a37",
+      "dependencies": [
+        "jsr:@std/internal",
+        "jsr:@std/path@^1.1.4"
+      ]
+    },
     "@std/internal@1.0.13": {
       "integrity": "2f9546691d4ac2d32859c82dff284aaeac980ddeca38430d07941e7e288725c0"
+    },
+    "@std/io@0.225.3": {
+      "integrity": "27b07b591384d12d7b568f39e61dff966b8230559122df1e9fd11cc068f7ddd1",
+      "dependencies": [
+        "jsr:@std/bytes"
+      ]
+    },
+    "@std/path@1.1.4": {
+      "integrity": "1d2d43f39efb1b42f0b1882a25486647cb851481862dc7313390b2bb044314b5",
+      "dependencies": [
+        "jsr:@std/internal"
+      ]
+    },
+    "@std/semver@1.0.8": {
+      "integrity": "dc830e8b8b6a380c895d53fbfd1258dc253704ca57bbe1629ac65fd7830179b7"
     }
   },
   "workspace": {

--- a/process-plugin.ts
+++ b/process-plugin.ts
@@ -144,8 +144,14 @@ export interface CreateDprintOrgNpmPackagesOptions {
    * the scope but not the basename of the main package).
    */
   subPackagePrefix?: string;
-  /** Per-platform zips that will be packed as sub-packages. */
-  platforms: { platform: Platform; zipFilePath: string }[];
+  /**
+   * Per-platform binaries that will be packed as sub-packages. Each
+   * `binaryPath` points to the raw executable on disk — it's copied
+   * into the sub-package under its basename, and the main package's
+   * `plugin.json` references it via `npm:<sub>@<version>/<basename>`.
+   * On Unix, the copied file is marked executable (mode 0o755).
+   */
+  platforms: { platform: Platform; binaryPath: string }[];
   /** Directory in which to write the package subdirectories. */
   outDir: string;
   /**
@@ -171,19 +177,21 @@ export interface CreateDprintOrgNpmPackagesResult {
  * Creates the npm package directory structure for a dprint-org process plugin.
  *
  * For each platform it writes
- * `<outDir>/<sub-package-basename>/{package.json, plugin.zip}`. Sub-package
- * `package.json` files carry `os`/`cpu`/`libc` filters using Node's canonical
- * values (e.g. `linux` / `x64` / `glibc`) so npm only installs the matching
- * one. The platform suffix matches the convention used by the dprint CLI:
- * `darwin-x64`, `darwin-arm64`, `linux-x64-glibc`, `linux-x64-musl`,
- * `linux-arm64-glibc`, `linux-arm64-musl`, `linux-riscv64-glibc`,
- * `linux-riscv64-musl`, `linux-loong64-glibc`, `linux-loong64-musl`,
- * `win32-x64`, `win32-arm64`.
+ * `<outDir>/<sub-package-basename>/{package.json, <binary>}`, where `<binary>`
+ * is the basename of the input `binaryPath` (e.g. `dprint-plugin-exec` or
+ * `dprint-plugin-exec.exe`). The binary is copied as-is and marked executable
+ * (mode 0o755) on Unix. Sub-package `package.json` files carry `os`/`cpu`/`libc`
+ * filters using Node's canonical values (e.g. `linux` / `x64` / `glibc`) so
+ * npm only installs the matching one. The platform suffix matches the
+ * convention used by the dprint CLI: `darwin-x64`, `darwin-arm64`,
+ * `linux-x64-glibc`, `linux-x64-musl`, `linux-arm64-glibc`,
+ * `linux-arm64-musl`, `linux-riscv64-glibc`, `linux-riscv64-musl`,
+ * `linux-loong64-glibc`, `linux-loong64-musl`, `win32-x64`, `win32-arm64`.
  *
  * It also writes the main package at
  * `<outDir>/<main-package-basename>/{package.json, plugin.json}`. The
  * `plugin.json` references each sub-package via
- * `npm:<sub-package>@<version>/plugin.zip` and the `package.json` lists every
+ * `npm:<sub-package>@<version>/<binary>` and the `package.json` lists every
  * sub-package as an `optionalDependencies` entry pinned to `version`.
  *
  * `basename` here is the last `/`-separated segment of the package name (e.g.
@@ -206,20 +214,26 @@ export async function createDprintOrgNpmPackages(
   const subPackageDirs: string[] = [];
   const optionalDependencies: Record<string, string> = {};
 
-  for (const { platform, zipFilePath } of options.platforms) {
+  for (const { platform, binaryPath } of options.platforms) {
     const info = npmPlatformInfo(platform);
     const subPackageName = `${subPackagePrefix}${info.suffix}`;
     const subPackageDir = `${options.outDir}/${packageBasename(subPackageName)}`;
+    const binaryName = basenameOf(binaryPath);
+    const destBinaryPath = `${subPackageDir}/${binaryName}`;
+
     await Deno.mkdir(subPackageDir, { recursive: true });
-    await Deno.copyFile(zipFilePath, `${subPackageDir}/plugin.zip`);
-    await writeJsonFile(`${subPackageDir}/package.json`, {
-      ...options.packageJsonExtra,
+    await Deno.copyFile(binaryPath, destBinaryPath);
+    // mark the destination executable on Unix; no-op on Windows (the platform
+    // has no concept and Deno.chmod throws there).
+    if (Deno.build.os !== "windows") {
+      await Deno.chmod(destBinaryPath, 0o755);
+    }
+    await writeSubPackageJson(`${subPackageDir}/package.json`, {
       name: subPackageName,
       version: options.version,
+      extra: options.packageJsonExtra,
       os: info.os,
       cpu: info.cpu,
-      // undefined keys are dropped by JSON.stringify, so this also overrides
-      // any `libc` field provided via packageJsonExtra for darwin/win32.
       libc: info.libc,
     });
     subPackageDirs.push(subPackageDir);
@@ -227,18 +241,18 @@ export async function createDprintOrgNpmPackages(
 
     await builder.addPlatform({
       platform,
-      zipFilePath,
-      zipUrl: `npm:${subPackageName}@${options.version}/plugin.zip`,
+      zipFilePath: binaryPath,
+      zipUrl: `npm:${subPackageName}@${options.version}/${binaryName}`,
     });
   }
 
   const mainPackageDir = `${options.outDir}/${packageBasename(options.mainPackageName)}`;
   await Deno.mkdir(mainPackageDir, { recursive: true });
   await builder.writeToPath(`${mainPackageDir}/plugin.json`);
-  await writeJsonFile(`${mainPackageDir}/package.json`, {
-    ...options.packageJsonExtra,
+  await writeMainPackageJson(`${mainPackageDir}/package.json`, {
     name: options.mainPackageName,
     version: options.version,
+    extra: options.packageJsonExtra,
     optionalDependencies,
   });
 
@@ -336,6 +350,86 @@ function npmPlatformInfo(platform: Platform): NpmPlatformInfo {
   }
 }
 
+async function writeSubPackageJson(
+  filePath: string,
+  fields: {
+    name: string;
+    version: string;
+    extra: Record<string, unknown> | undefined;
+    os: string[];
+    cpu: string[];
+    libc: string[] | undefined;
+  },
+): Promise<void> {
+  await writeJsonFile(
+    filePath,
+    buildPackageJson(
+      { name: fields.name, version: fields.version },
+      fields.extra,
+      { os: fields.os, cpu: fields.cpu, libc: fields.libc },
+    ),
+  );
+}
+
+async function writeMainPackageJson(
+  filePath: string,
+  fields: {
+    name: string;
+    version: string;
+    extra: Record<string, unknown> | undefined;
+    optionalDependencies: Record<string, string>;
+  },
+): Promise<void> {
+  await writeJsonFile(
+    filePath,
+    buildPackageJson(
+      { name: fields.name, version: fields.version },
+      fields.extra,
+      { optionalDependencies: fields.optionalDependencies },
+    ),
+  );
+}
+
+/**
+ * Builds a package.json object with `name` and `version` at the top, then
+ * the caller-supplied extras, then any trailing managed fields (os, cpu,
+ * libc, optionalDependencies). Extras' attempts to override managed fields
+ * are silently dropped.
+ */
+function buildPackageJson(
+  head: { name: string; version: string },
+  extra: Record<string, unknown> | undefined,
+  trailing: Record<string, unknown>,
+): Record<string, unknown> {
+  const managedKeys = new Set([
+    "name",
+    "version",
+    ...Object.keys(trailing),
+  ]);
+  const result: Record<string, unknown> = {
+    name: head.name,
+    version: head.version,
+  };
+  if (extra != null) {
+    for (const [k, v] of Object.entries(extra)) {
+      if (managedKeys.has(k)) continue;
+      result[k] = v;
+    }
+  }
+  for (const [k, v] of Object.entries(trailing)) {
+    // undefined values are dropped by JSON.stringify, so this still
+    // suppresses e.g. `libc` on platforms that don't need it.
+    result[k] = v;
+  }
+  return result;
+}
+
 async function writeJsonFile(filePath: string, value: unknown): Promise<void> {
   await Deno.writeTextFile(filePath, JSON.stringify(value, undefined, 2) + "\n");
+}
+
+function basenameOf(path: string): string {
+  // accept both / and \ for cross-platform input paths
+  const slash = Math.max(path.lastIndexOf("/"), path.lastIndexOf("\\"));
+  return slash >= 0 ? path.substring(slash + 1) : path;
 }

--- a/process-plugin_test.ts
+++ b/process-plugin_test.ts
@@ -75,15 +75,15 @@ Deno.test("PluginFileBuilder.writeToPath writes outputText verbatim", async () =
 
 Deno.test("createDprintOrgNpmPackages: full layout for plugin convention", async () => {
   await withTempDir(async (root) => {
-    const linuxZip = `${root}/linux.zip`;
-    const darwinZip = `${root}/darwin.zip`;
-    const winZip = `${root}/win.zip`;
-    const linuxBytes = new TextEncoder().encode("linux zip content");
-    const darwinBytes = new TextEncoder().encode("darwin zip content");
-    const winBytes = new TextEncoder().encode("win zip content");
-    await Deno.writeFile(linuxZip, linuxBytes);
-    await Deno.writeFile(darwinZip, darwinBytes);
-    await Deno.writeFile(winZip, winBytes);
+    const linuxBinary = `${root}/dprint-plugin-exec-linux`;
+    const darwinBinary = `${root}/dprint-plugin-exec-darwin`;
+    const winBinary = `${root}/dprint-plugin-exec.exe`;
+    const linuxBytes = new TextEncoder().encode("linux binary content");
+    const darwinBytes = new TextEncoder().encode("darwin binary content");
+    const winBytes = new TextEncoder().encode("win binary content");
+    await Deno.writeFile(linuxBinary, linuxBytes);
+    await Deno.writeFile(darwinBinary, darwinBytes);
+    await Deno.writeFile(winBinary, winBytes);
 
     const outDir = `${root}/out`;
     const result = await createDprintOrgNpmPackages({
@@ -92,9 +92,9 @@ Deno.test("createDprintOrgNpmPackages: full layout for plugin convention", async
       mainPackageName: "@dprint/exec",
       outDir,
       platforms: [
-        { platform: "linux-x86_64", zipFilePath: linuxZip },
-        { platform: "darwin-aarch64", zipFilePath: darwinZip },
-        { platform: "windows-x86_64", zipFilePath: winZip },
+        { platform: "linux-x86_64", binaryPath: linuxBinary },
+        { platform: "darwin-aarch64", binaryPath: darwinBinary },
+        { platform: "windows-x86_64", binaryPath: winBinary },
       ],
     });
 
@@ -106,12 +106,12 @@ Deno.test("createDprintOrgNpmPackages: full layout for plugin convention", async
     ]);
 
     assertEquals(await listRelativeFiles(outDir), [
+      "exec-darwin-arm64/dprint-plugin-exec-darwin",
       "exec-darwin-arm64/package.json",
-      "exec-darwin-arm64/plugin.zip",
+      "exec-linux-x64-glibc/dprint-plugin-exec-linux",
       "exec-linux-x64-glibc/package.json",
-      "exec-linux-x64-glibc/plugin.zip",
+      "exec-win32-x64/dprint-plugin-exec.exe",
       "exec-win32-x64/package.json",
-      "exec-win32-x64/plugin.zip",
       "exec/package.json",
       "exec/plugin.json",
     ]);
@@ -137,15 +137,15 @@ Deno.test("createDprintOrgNpmPackages: full layout for plugin convention", async
         name: "dprint-plugin-exec",
         version: "1.2.3",
         "linux-x86_64": {
-          reference: "npm:@dprint/exec-linux-x64-glibc@1.2.3/plugin.zip",
+          reference: "npm:@dprint/exec-linux-x64-glibc@1.2.3/dprint-plugin-exec-linux",
           checksum: await getChecksum(linuxBytes),
         },
         "darwin-aarch64": {
-          reference: "npm:@dprint/exec-darwin-arm64@1.2.3/plugin.zip",
+          reference: "npm:@dprint/exec-darwin-arm64@1.2.3/dprint-plugin-exec-darwin",
           checksum: await getChecksum(darwinBytes),
         },
         "windows-x86_64": {
-          reference: "npm:@dprint/exec-win32-x64@1.2.3/plugin.zip",
+          reference: "npm:@dprint/exec-win32-x64@1.2.3/dprint-plugin-exec.exe",
           checksum: await getChecksum(winBytes),
         },
       },
@@ -188,17 +188,56 @@ Deno.test("createDprintOrgNpmPackages: full layout for plugin convention", async
       },
     );
 
+    // binary is copied verbatim into the sub-package
     assertEquals(
-      await Deno.readFile(`${outDir}/exec-linux-x64-glibc/plugin.zip`),
+      await Deno.readFile(`${outDir}/exec-linux-x64-glibc/dprint-plugin-exec-linux`),
       linuxBytes,
     );
+    assertEquals(
+      await Deno.readFile(`${outDir}/exec-win32-x64/dprint-plugin-exec.exe`),
+      winBytes,
+    );
+  });
+});
+
+Deno.test("createDprintOrgNpmPackages: name and version are the first keys in package.json", async () => {
+  await withTempDir(async (root) => {
+    const binary = `${root}/dprint-plugin-exec`;
+    await Deno.writeFile(binary, new Uint8Array([0]));
+
+    const outDir = `${root}/out`;
+    await createDprintOrgNpmPackages({
+      pluginName: "dprint-plugin-exec",
+      version: "1.0.0",
+      mainPackageName: "@dprint/exec",
+      outDir,
+      platforms: [{ platform: "linux-x86_64", binaryPath: binary }],
+      packageJsonExtra: {
+        description: "desc",
+        license: "MIT",
+      },
+    });
+
+    const mainKeys = Object.keys(
+      JSON.parse(await Deno.readTextFile(`${outDir}/exec/package.json`)),
+    );
+    assertEquals(mainKeys.slice(0, 2), ["name", "version"]);
+
+    const subKeys = Object.keys(
+      JSON.parse(
+        await Deno.readTextFile(`${outDir}/exec-linux-x64-glibc/package.json`),
+      ),
+    );
+    assertEquals(subKeys.slice(0, 2), ["name", "version"]);
   });
 });
 
 Deno.test("createDprintOrgNpmPackages: subPackagePrefix produces CLI-style names", async () => {
   await withTempDir(async (root) => {
-    const zip = `${root}/z.zip`;
-    await Deno.writeFile(zip, new Uint8Array([1, 2, 3]));
+    const unixBinary = `${root}/dprint`;
+    const winBinary = `${root}/dprint.exe`;
+    await Deno.writeFile(unixBinary, new Uint8Array([1, 2, 3]));
+    await Deno.writeFile(winBinary, new Uint8Array([1, 2, 3]));
 
     const outDir = `${root}/out`;
     const result = await createDprintOrgNpmPackages({
@@ -208,8 +247,8 @@ Deno.test("createDprintOrgNpmPackages: subPackagePrefix produces CLI-style names
       subPackagePrefix: "@dprint/",
       outDir,
       platforms: [
-        { platform: "linux-x86_64", zipFilePath: zip },
-        { platform: "windows-x86_64", zipFilePath: zip },
+        { platform: "linux-x86_64", binaryPath: unixBinary },
+        { platform: "windows-x86_64", binaryPath: winBinary },
       ],
     });
 
@@ -240,19 +279,19 @@ Deno.test("createDprintOrgNpmPackages: subPackagePrefix produces CLI-style names
     );
     assertEquals(
       pluginJson["linux-x86_64"].reference,
-      "npm:@dprint/linux-x64-glibc@0.54.0/plugin.zip",
+      "npm:@dprint/linux-x64-glibc@0.54.0/dprint",
     );
     assertEquals(
       pluginJson["windows-x86_64"].reference,
-      "npm:@dprint/win32-x64@0.54.0/plugin.zip",
+      "npm:@dprint/win32-x64@0.54.0/dprint.exe",
     );
   });
 });
 
 Deno.test("createDprintOrgNpmPackages: packageJsonExtra merges but managed fields win", async () => {
   await withTempDir(async (root) => {
-    const zip = `${root}/z.zip`;
-    await Deno.writeFile(zip, new Uint8Array([0]));
+    const binary = `${root}/p`;
+    await Deno.writeFile(binary, new Uint8Array([0]));
 
     const outDir = `${root}/out`;
     await createDprintOrgNpmPackages({
@@ -263,7 +302,7 @@ Deno.test("createDprintOrgNpmPackages: packageJsonExtra merges but managed field
       platforms: [
         // darwin has no libc — managed override must drop a stray
         // libc value supplied via packageJsonExtra.
-        { platform: "darwin-aarch64", zipFilePath: zip },
+        { platform: "darwin-aarch64", binaryPath: binary },
       ],
       packageJsonExtra: {
         description: "desc",


### PR DESCRIPTION
## Summary

dprint now supports referencing a raw executable from a process plugin's per-platform npm sub-package, so the helper no longer needs to wrap the binary in a `.zip`. Two changes:

1. **Raw binaries in sub-packages.** `CreateDprintOrgNpmPackagesOptions.platforms[].zipFilePath` is renamed to `binaryPath` (breaking — only one PR was using it). The file at `binaryPath` is copied verbatim into the sub-package under its basename, marked executable (mode 0o755) on Unix, and referenced from the main package's `plugin.json` as `npm:<sub-package>@<version>/<basename>` instead of `.../plugin.zip`.

2. **`name` and `version` at the top of `package.json`.** Generated `package.json` files now order keys as: `name`, `version`, then caller-supplied `packageJsonExtra` (any fields that collide with managed keys are dropped), then managed platform/dependency fields (`os`/`cpu`/`libc` for sub-packages, `optionalDependencies` for the main).

## Caveats

- **Cross-OS publishing.** Running `npm pack`/`publish` from Windows packs files without the Unix executable bit, because the host filesystem can't carry that mode. CI on Ubuntu is fine; for local bootstrap publishes, use a Unix host.
- Existing `PluginFileBuilder` API is unchanged — the `zipFilePath`/`zipUrl` parameter names are now slightly misleading (they accept any file) but the behavior is general and renaming would break `create_plugin_file.ts` style callers that still ship zips via GitHub releases.

## Test plan

- [x] `deno test -P` — 7/7 pass, including a new test pinning the `name`/`version`-at-top contract and updated assertions for the new reference URL format.
- [x] `deno check` / `dprint check` clean.
- [ ] After release, `dprint-plugin-exec`'s `create_npm_packages.ts` will be updated to extract the platform zips and pass the binaries through to the helper.