### PR TITLE
fix: per-platform checksums are sha256 of the npm tarball

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,10 @@ jobs:
         uses: denoland/setup-deno@v2
         with:
           deno-version: canary
+      - name: Install node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22.x
       - name: Test
         run: deno test -P
       - name: Publish to JSR on tag

--- a/process-plugin.ts
+++ b/process-plugin.ts
@@ -106,6 +106,18 @@ export class PluginFileBuilder {
     };
   }
 
+  /**
+   * Adds a platform entry with a precomputed checksum. Use this when the
+   * checksum doesn't correspond to a single file on disk (e.g. it covers
+   * a npm tarball that has already been packed and hashed).
+   */
+  addPlatformEntry(options: { platform: Platform; reference: string; checksum: string }) {
+    this.#output[options.platform] = {
+      "reference": options.reference,
+      "checksum": options.checksum,
+    };
+  }
+
   async writeToPath(filePath: string) {
     const text = this.outputText();
     const checksum = await this.outputTextChecksum();
@@ -164,13 +176,24 @@ export interface CreateDprintOrgNpmPackagesOptions {
 
 /** Result of {@link createDprintOrgNpmPackages}. */
 export interface CreateDprintOrgNpmPackagesResult {
-  /** Directory containing the main package (run `npm publish` here last). */
+  /** Directory containing the main package. */
   mainPackageDir: string;
   /**
-   * Directories containing the per-platform sub-packages. Publish these
-   * before the main package so its `optionalDependencies` resolve.
+   * Tarball for the main package. Publish this last with
+   * `npm publish <path>` so npm uploads the exact bytes whose hash users
+   * verify, rather than re-packing and risking a hash mismatch.
    */
+  mainPackageTarball: string;
+  /** Directories containing the per-platform sub-packages. */
   subPackageDirs: string[];
+  /**
+   * Tarballs for each per-platform sub-package, in the same order as
+   * {@link subPackageDirs}. The SHA-256 of each tarball is the value
+   * stored in the main package's `plugin.json` per-platform `checksum`
+   * field, so publishing the same tarball ensures dprint's verification
+   * succeeds. Publish these before {@link mainPackageTarball}.
+   */
+  subPackageTarballs: string[];
 }
 
 /**
@@ -188,31 +211,45 @@ export interface CreateDprintOrgNpmPackagesResult {
  * `linux-arm64-musl`, `linux-riscv64-glibc`, `linux-riscv64-musl`,
  * `linux-loong64-glibc`, `linux-loong64-musl`, `win32-x64`, `win32-arm64`.
  *
- * It also writes the main package at
- * `<outDir>/<main-package-basename>/{package.json, plugin.json}`. The
- * `plugin.json` references each sub-package via
+ * After each sub-package dir is written, `npm pack` is run inside it to
+ * produce a `.tgz` next to the dir; the SHA-256 of that tarball becomes
+ * the per-platform `checksum` in the main package's `plugin.json` —
+ * matching dprint's per-platform tarball-hash verification.
+ *
+ * Finally the main package is written to
+ * `<outDir>/<main-package-basename>/{package.json, plugin.json}` and packed
+ * the same way. The `plugin.json` references each sub-package via
  * `npm:<sub-package>@<version>/<binary>` and the `package.json` lists every
  * sub-package as an `optionalDependencies` entry pinned to `version`.
  *
  * `basename` here is the last `/`-separated segment of the package name (e.g.
  * `@dprint/exec` → `exec`).
  *
- * The caller is expected to `npm publish` each sub-package directory first,
- * then the main package directory.
+ * The caller is expected to `npm publish <tarball>` each sub-package
+ * tarball first, then the main package tarball. Publishing the tarballs
+ * (rather than the directories) guarantees the published bytes match
+ * what was hashed.
+ *
+ * `npm` must be on `PATH` when calling this function.
  */
 export async function createDprintOrgNpmPackages(
   options: CreateDprintOrgNpmPackagesOptions,
 ): Promise<CreateDprintOrgNpmPackagesResult> {
-  const builder = new PluginFileBuilder({
-    name: options.pluginName,
-    version: options.version,
-  });
-
   await Deno.mkdir(options.outDir, { recursive: true });
 
   const subPackagePrefix = options.subPackagePrefix ?? `${options.mainPackageName}-`;
   const subPackageDirs: string[] = [];
+  const subPackageTarballs: string[] = [];
   const optionalDependencies: Record<string, string> = {};
+
+  // pass 1: write each sub-package directory.
+  interface PendingSubPackage {
+    platform: Platform;
+    subPackageName: string;
+    subPackageDir: string;
+    binaryName: string;
+  }
+  const pending: PendingSubPackage[] = [];
 
   for (const { platform, binaryPath } of options.platforms) {
     const info = npmPlatformInfo(platform);
@@ -238,14 +275,27 @@ export async function createDprintOrgNpmPackages(
     });
     subPackageDirs.push(subPackageDir);
     optionalDependencies[subPackageName] = options.version;
+    pending.push({ platform, subPackageName, subPackageDir, binaryName });
+  }
 
-    await builder.addPlatform({
+  // pass 2: npm pack each sub-package and hash its tarball.
+  const builder = new PluginFileBuilder({
+    name: options.pluginName,
+    version: options.version,
+  });
+  for (const { platform, subPackageName, subPackageDir, binaryName } of pending) {
+    const tarball = await npmPack(subPackageDir, options.outDir);
+    subPackageTarballs.push(tarball);
+    const checksum = await getChecksum(await Deno.readFile(tarball));
+    console.log(`${tarball}: ${checksum}`);
+    builder.addPlatformEntry({
       platform,
-      zipFilePath: binaryPath,
-      zipUrl: `npm:${subPackageName}@${options.version}/${binaryName}`,
+      reference: `npm:${subPackageName}@${options.version}/${binaryName}`,
+      checksum,
     });
   }
 
+  // pass 3: write the main package, then pack it.
   const mainPackageDir = `${options.outDir}/${packageBasename(options.mainPackageName)}`;
   await Deno.mkdir(mainPackageDir, { recursive: true });
   await builder.writeToPath(`${mainPackageDir}/plugin.json`);
@@ -255,8 +305,9 @@ export async function createDprintOrgNpmPackages(
     extra: options.packageJsonExtra,
     optionalDependencies,
   });
+  const mainPackageTarball = await npmPack(mainPackageDir, options.outDir);
 
-  return { mainPackageDir, subPackageDirs };
+  return { mainPackageDir, mainPackageTarball, subPackageDirs, subPackageTarballs };
 }
 
 /** Creates a process plugin for the dprint GitHub organization. */
@@ -426,6 +477,35 @@ function buildPackageJson(
 
 async function writeJsonFile(filePath: string, value: unknown): Promise<void> {
   await Deno.writeTextFile(filePath, JSON.stringify(value, undefined, 2) + "\n");
+}
+
+/**
+ * Runs `npm pack` against `packageDir` and writes the tarball into
+ * `destDir`. Returns the absolute path to the .tgz. Requires `npm` on PATH.
+ */
+async function npmPack(packageDir: string, destDir: string): Promise<string> {
+  const out = await new Deno.Command("npm", {
+    args: ["pack", "--json", "--pack-destination", destDir, packageDir],
+    stdout: "piped",
+    stderr: "piped",
+  }).output().catch((err: unknown) => {
+    if (err instanceof Deno.errors.NotFound) {
+      throw new Error("createDprintOrgNpmPackages requires `npm` on PATH (used for `npm pack`).");
+    }
+    throw err;
+  });
+  if (!out.success) {
+    throw new Error(
+      `npm pack failed for ${packageDir}:\n${new TextDecoder().decode(out.stderr)}`,
+    );
+  }
+  const parsed = JSON.parse(new TextDecoder().decode(out.stdout)) as Array<{
+    filename: string;
+  }>;
+  if (parsed.length !== 1 || !parsed[0].filename) {
+    throw new Error(`Unexpected npm pack JSON output for ${packageDir}: ${new TextDecoder().decode(out.stdout)}`);
+  }
+  return `${destDir}/${parsed[0].filename}`;
 }
 
 function basenameOf(path: string): string {

--- a/process-plugin_test.ts
+++ b/process-plugin_test.ts
@@ -86,16 +86,17 @@ Deno.test("createDprintOrgNpmPackages: full layout for plugin convention", async
     await Deno.writeFile(winBinary, winBytes);
 
     const outDir = `${root}/out`;
+    const platforms: Array<{ platform: Platform; binaryPath: string }> = [
+      { platform: "linux-x86_64", binaryPath: linuxBinary },
+      { platform: "darwin-aarch64", binaryPath: darwinBinary },
+      { platform: "windows-x86_64", binaryPath: winBinary },
+    ];
     const result = await createDprintOrgNpmPackages({
       pluginName: "dprint-plugin-exec",
       version: "1.2.3",
       mainPackageName: "@dprint/exec",
       outDir,
-      platforms: [
-        { platform: "linux-x86_64", binaryPath: linuxBinary },
-        { platform: "darwin-aarch64", binaryPath: darwinBinary },
-        { platform: "windows-x86_64", binaryPath: winBinary },
-      ],
+      platforms,
     });
 
     assertEquals(result.mainPackageDir, `${outDir}/exec`);
@@ -105,16 +106,11 @@ Deno.test("createDprintOrgNpmPackages: full layout for plugin convention", async
       `${outDir}/exec-win32-x64`,
     ]);
 
-    assertEquals(await listRelativeFiles(outDir), [
-      "exec-darwin-arm64/dprint-plugin-exec-darwin",
-      "exec-darwin-arm64/package.json",
-      "exec-linux-x64-glibc/dprint-plugin-exec-linux",
-      "exec-linux-x64-glibc/package.json",
-      "exec-win32-x64/dprint-plugin-exec.exe",
-      "exec-win32-x64/package.json",
-      "exec/package.json",
-      "exec/plugin.json",
-    ]);
+    // tarballs exist and are non-empty
+    for (const t of [...result.subPackageTarballs, result.mainPackageTarball]) {
+      const stat = await Deno.stat(t);
+      assertEquals(stat.size > 0, true, `${t} should be non-empty`);
+    }
 
     assertEquals(
       JSON.parse(await Deno.readTextFile(`${outDir}/exec/package.json`)),
@@ -129,27 +125,28 @@ Deno.test("createDprintOrgNpmPackages: full layout for plugin convention", async
       },
     );
 
-    assertEquals(
-      JSON.parse(await Deno.readTextFile(`${outDir}/exec/plugin.json`)),
-      {
-        schemaVersion: 2,
-        kind: "process",
-        name: "dprint-plugin-exec",
-        version: "1.2.3",
-        "linux-x86_64": {
-          reference: "npm:@dprint/exec-linux-x64-glibc@1.2.3/dprint-plugin-exec-linux",
-          checksum: await getChecksum(linuxBytes),
-        },
-        "darwin-aarch64": {
-          reference: "npm:@dprint/exec-darwin-arm64@1.2.3/dprint-plugin-exec-darwin",
-          checksum: await getChecksum(darwinBytes),
-        },
-        "windows-x86_64": {
-          reference: "npm:@dprint/exec-win32-x64@1.2.3/dprint-plugin-exec.exe",
-          checksum: await getChecksum(winBytes),
-        },
-      },
-    );
+    // plugin.json shape: per-platform reference correct, checksum is sha256 of the matching tarball.
+    const pluginJson = JSON.parse(await Deno.readTextFile(`${outDir}/exec/plugin.json`));
+    assertEquals(pluginJson.schemaVersion, 2);
+    assertEquals(pluginJson.kind, "process");
+    assertEquals(pluginJson.name, "dprint-plugin-exec");
+    assertEquals(pluginJson.version, "1.2.3");
+
+    const expectedRefs: Record<string, string> = {
+      "linux-x86_64": "npm:@dprint/exec-linux-x64-glibc@1.2.3/dprint-plugin-exec-linux",
+      "darwin-aarch64": "npm:@dprint/exec-darwin-arm64@1.2.3/dprint-plugin-exec-darwin",
+      "windows-x86_64": "npm:@dprint/exec-win32-x64@1.2.3/dprint-plugin-exec.exe",
+    };
+    for (let i = 0; i < platforms.length; i++) {
+      const key = platforms[i].platform;
+      const entry = pluginJson[key];
+      assertEquals(entry.reference, expectedRefs[key]);
+      assertEquals(
+        entry.checksum,
+        await getChecksum(await Deno.readFile(result.subPackageTarballs[i])),
+        `checksum for ${key} should equal sha256 of its tarball`,
+      );
+    }
 
     assertEquals(
       JSON.parse(


### PR DESCRIPTION
## Summary

Matches dprint's recent shift to verifying the per-platform `checksum` in `plugin.json` against the SHA-256 of the per-platform **npm tarball** (rather than just the binary file at the reference path). dprint fetches the tarball directly from the registry on resolve and reads the binary from the extracted contents — see the dprint commit \"Verify the per-platform tarball hash, not the binary's, for npm process plugins\".

## Changes

- **`createDprintOrgNpmPackages`** now runs \`npm pack\` against each sub-package after its directory is written, then SHA-256s the resulting \`.tgz\`. That hash goes into the main package's \`plugin.json\` per-platform entry. The main package is then packed the same way.
- **\`CreateDprintOrgNpmPackagesResult\`** gains \`mainPackageTarball\` and \`subPackageTarballs\`. Callers should \`npm publish <tarball>\` (rather than \`npm publish <dir>\`) so npm uploads the exact bytes whose hash users verify — avoiding any drift from npm re-packing the directory.
- **\`PluginFileBuilder.addPlatformEntry\`** (new) accepts a precomputed reference + checksum, used by the function above. The existing \`addPlatform\` (which reads-and-hashes a file) is unchanged.
- **Runtime requirement:** \`npm\` must be on \`PATH\` when calling \`createDprintOrgNpmPackages\`. A clear error is thrown otherwise.
- **CI** installs node 22 alongside deno so \`deno test\` can shell out to \`npm pack\`.

## Test plan

- [x] 7/7 tests pass locally (\`deno test -P\`).
- [x] New assertion: per-platform \`checksum\` in plugin.json equals \`sha256(result.subPackageTarballs[i])\`. Avoids brittleness from depending on a specific npm version's exact byte-for-byte tarball output.
- [x] \`dprint check\` clean.
- [ ] After merge + release: \`dprint-plugin-exec\`'s \`scripts/create_npm_packages.ts\` and \`publish_npm_packages.ts\` will be updated to publish tarballs.