### PR TITLE
feat: per-platform packageContents for multi-file sub-packages

### DIFF
--- a/process-plugin.ts
+++ b/process-plugin.ts
@@ -162,8 +162,18 @@ export interface CreateDprintOrgNpmPackagesOptions {
    * into the sub-package under its basename, and the main package's
    * `plugin.json` references it via `npm:<sub>@<version>/<basename>`.
    * On Unix, the copied file is marked executable (mode 0o755).
+   *
+   * For plugins whose executable can't run standalone (e.g. self-contained
+   * .NET apps that ship with side-loaded DLLs), set `packageContents` to
+   * the directory whose contents should be copied into the sub-package.
+   * `binaryPath` must be a file inside that directory; everything else in
+   * the directory is copied verbatim, preserving relative paths.
    */
-  platforms: { platform: Platform; binaryPath: string }[];
+  platforms: {
+    platform: Platform;
+    binaryPath: string;
+    packageContents?: string;
+  }[];
   /** Directory in which to write the package subdirectories. */
   outDir: string;
   /**
@@ -251,7 +261,7 @@ export async function createDprintOrgNpmPackages(
   }
   const pending: PendingSubPackage[] = [];
 
-  for (const { platform, binaryPath } of options.platforms) {
+  for (const { platform, binaryPath, packageContents } of options.platforms) {
     const info = npmPlatformInfo(platform);
     const subPackageName = `${subPackagePrefix}${info.suffix}`;
     const subPackageDir = `${options.outDir}/${packageBasename(subPackageName)}`;
@@ -259,7 +269,17 @@ export async function createDprintOrgNpmPackages(
     const destBinaryPath = `${subPackageDir}/${binaryName}`;
 
     await Deno.mkdir(subPackageDir, { recursive: true });
-    await Deno.copyFile(binaryPath, destBinaryPath);
+    if (packageContents != null) {
+      const binaryRelInDir = relativePathInside(packageContents, binaryPath);
+      if (binaryRelInDir == null) {
+        throw new Error(
+          `binaryPath ${binaryPath} must be inside packageContents ${packageContents}`,
+        );
+      }
+      await copyDirContents(packageContents, subPackageDir);
+    } else {
+      await Deno.copyFile(binaryPath, destBinaryPath);
+    }
     // mark the destination executable on Unix; no-op on Windows (the platform
     // has no concept and Deno.chmod throws there).
     if (Deno.build.os !== "windows") {
@@ -512,4 +532,39 @@ function basenameOf(path: string): string {
   // accept both / and \ for cross-platform input paths
   const slash = Math.max(path.lastIndexOf("/"), path.lastIndexOf("\\"));
   return slash >= 0 ? path.substring(slash + 1) : path;
+}
+
+/**
+ * Recursively copies the contents of `src` into `dest`. `dest` must already
+ * exist. Sub-directories are created as needed. File modes are preserved on
+ * Unix (so e.g. a pre-existing executable bit survives the copy); on Windows
+ * the OS doesn't carry modes so npm pack will record 0644.
+ */
+async function copyDirContents(src: string, dest: string): Promise<void> {
+  for await (const entry of Deno.readDir(src)) {
+    const srcPath = `${src}/${entry.name}`;
+    const destPath = `${dest}/${entry.name}`;
+    if (entry.isDirectory) {
+      await Deno.mkdir(destPath, { recursive: true });
+      await copyDirContents(srcPath, destPath);
+    } else {
+      await Deno.copyFile(srcPath, destPath);
+    }
+  }
+}
+
+/**
+ * Returns `child` expressed relative to `parent` using forward slashes, or
+ * `null` if `child` is not inside `parent`. Both paths are normalized to use
+ * forward slashes first so this works regardless of input separator style.
+ */
+function relativePathInside(parent: string, child: string): string | null {
+  const p = normalizeSlashes(parent).replace(/\/+$/, "") + "/";
+  const c = normalizeSlashes(child);
+  if (!c.startsWith(p)) return null;
+  return c.substring(p.length);
+}
+
+function normalizeSlashes(path: string): string {
+  return path.replaceAll("\\", "/");
 }

--- a/process-plugin_test.ts
+++ b/process-plugin_test.ts
@@ -229,6 +229,79 @@ Deno.test("createDprintOrgNpmPackages: name and version are the first keys in pa
   });
 });
 
+Deno.test("createDprintOrgNpmPackages: packageContents ships the whole dir", async () => {
+  await withTempDir(async (root) => {
+    // simulate a self-contained .NET app layout: an executable plus side
+    // files (including in a sub-dir) that must travel together.
+    const appDir = `${root}/app`;
+    await Deno.mkdir(`${appDir}/runtimes`, { recursive: true });
+    const binaryPath = `${appDir}/dprint-plugin-roslyn`;
+    await Deno.writeFile(binaryPath, new TextEncoder().encode("bin"));
+    await Deno.writeFile(`${appDir}/Microsoft.CodeAnalysis.dll`, new TextEncoder().encode("dll1"));
+    await Deno.writeFile(`${appDir}/Microsoft.CSharp.dll`, new TextEncoder().encode("dll2"));
+    await Deno.writeFile(`${appDir}/runtimes/libSystem.Native.so`, new TextEncoder().encode("so"));
+
+    const outDir = `${root}/out`;
+    const result = await createDprintOrgNpmPackages({
+      pluginName: "dprint-plugin-roslyn",
+      version: "1.0.0",
+      mainPackageName: "@dprint/roslyn",
+      outDir,
+      platforms: [{ platform: "linux-x86_64", binaryPath, packageContents: appDir }],
+    });
+
+    // every file from appDir is now in the sub-package
+    const subDir = `${outDir}/roslyn-linux-x64-glibc`;
+    assertEquals(await Deno.readTextFile(`${subDir}/dprint-plugin-roslyn`), "bin");
+    assertEquals(await Deno.readTextFile(`${subDir}/Microsoft.CodeAnalysis.dll`), "dll1");
+    assertEquals(await Deno.readTextFile(`${subDir}/Microsoft.CSharp.dll`), "dll2");
+    assertEquals(await Deno.readTextFile(`${subDir}/runtimes/libSystem.Native.so`), "so");
+
+    // plugin.json's reference still names the executable; checksum is the
+    // tarball's sha256, which captures every file we just shipped.
+    const pluginJson = JSON.parse(await Deno.readTextFile(`${outDir}/roslyn/plugin.json`));
+    assertEquals(
+      pluginJson["linux-x86_64"].reference,
+      "npm:@dprint/roslyn-linux-x64-glibc@1.0.0/dprint-plugin-roslyn",
+    );
+    assertEquals(
+      pluginJson["linux-x86_64"].checksum,
+      await getChecksum(await Deno.readFile(result.subPackageTarballs[0])),
+    );
+  });
+});
+
+Deno.test("createDprintOrgNpmPackages: packageContents rejects binaryPath outside the dir", async () => {
+  await withTempDir(async (root) => {
+    await Deno.mkdir(`${root}/app`);
+    await Deno.writeFile(`${root}/app/inside`, new Uint8Array([1]));
+    const outsideBinary = `${root}/outside`;
+    await Deno.writeFile(outsideBinary, new Uint8Array([1]));
+
+    let threw = false;
+    try {
+      await createDprintOrgNpmPackages({
+        pluginName: "p",
+        version: "1.0.0",
+        mainPackageName: "@x/p",
+        outDir: `${root}/out`,
+        platforms: [{
+          platform: "linux-x86_64",
+          binaryPath: outsideBinary,
+          packageContents: `${root}/app`,
+        }],
+      });
+    } catch (err) {
+      threw = true;
+      assertEquals(
+        (err as Error).message.includes("must be inside packageContents"),
+        true,
+      );
+    }
+    assertEquals(threw, true, "expected an error");
+  });
+});
+
 Deno.test("createDprintOrgNpmPackages: subPackagePrefix produces CLI-style names", async () => {
   await withTempDir(async (root) => {
     const unixBinary = `${root}/dprint`;


### PR DESCRIPTION
## Summary

Some process plugins ship more than a standalone binary — e.g. a self-contained .NET app where the executable references DLLs and a native runtime in the same directory (`dprint-plugin-roslyn` extracts to ~205 files). The new optional `packageContents` per-platform field lets the helper ship the whole directory instead of just one file.

\`\`\`ts
platforms: [{
  platform: \"linux-x86_64\",
  binaryPath: \"./out/linux-x64/dprint-plugin-roslyn\",
  packageContents: \"./out/linux-x64\",
}]
\`\`\`

When set:
- The entire directory is copied recursively into the sub-package, preserving nested layout.
- \`binaryPath\` must be a file inside \`packageContents\` (validated). Its basename still names the executable in the npm reference URL, and it still gets \`chmod 0o755\` on Unix.
- The per-platform checksum in \`plugin.json\` is the sha256 of the resulting tarball, so it covers every shipped file — not just the executable.

When \`packageContents\` is unset: behavior is unchanged (single-file copy).

## Test plan

- [x] \`deno test -P\` — 9/9 pass, including:
  - new \"packageContents ships the whole dir\" test that asserts executable + multiple DLLs + a nested sub-directory file all land in the sub-package, and that plugin.json's checksum matches sha256 of the resulting tarball
  - new validation test that rejects a \`binaryPath\` outside the supplied \`packageContents\` directory
- [x] \`deno check\` / \`dprint check\` clean.
- [ ] After release, will be used by \`dprint-plugin-roslyn\`'s upcoming \`create_npm_packages.ts\`.